### PR TITLE
Automatic modules

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -99,4 +99,22 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.folio.tlib</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
 </project>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -105,4 +105,22 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.folio.tlib.example</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
 </project>

--- a/example/src/test/java/org/folio/tlib/example/MainVerticleTest.java
+++ b/example/src/test/java/org/folio/tlib/example/MainVerticleTest.java
@@ -12,7 +12,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.okapi.common.XOkapiHeaders;
-import org.folio.tlib.postgres.TenantPgPoolContainer;
+import org.folio.tlib.postgres.testing.TenantPgPoolContainer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;

--- a/pg-testing/pom.xml
+++ b/pg-testing/pom.xml
@@ -97,4 +97,22 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.folio.tlib.postgres.testing</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
 </project>

--- a/pg-testing/src/main/java/org/folio/tlib/postgres/testing/TenantPgPoolContainer.java
+++ b/pg-testing/src/main/java/org/folio/tlib/postgres/testing/TenantPgPoolContainer.java
@@ -1,6 +1,7 @@
-package org.folio.tlib.postgres;
+package org.folio.tlib.postgres.testing;
 
 import io.vertx.pgclient.PgConnectOptions;
+import org.folio.tlib.postgres.TenantPgPool;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 public final class TenantPgPoolContainer {

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,18 @@
   </dependencyManagement>
 
   <build>
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -99,6 +111,22 @@
         <configuration>
           <release>11</release>
           <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jdeps-plugin</artifactId>
+        <version>3.1.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>jdkinternals</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <multiRelease>base</multiRelease>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Make all modules automatic modules:
https://dzone.com/articles/automatic-module-name-calling-all-java-library-maintainers

* Add Automatic-Module-Name to MANIFEST.MF
* maven-jdeps-plugin for JDeps jdk-internals check
* Fix split package org.folio.tlib.postgres by moving TenantPgPoolContainer.java into testing package

Most dependencies already are automatic modules:
* https://github.com/search?q=org%3Aeclipse-vertx+Automatic-Module-Name&type=Code
* https://github.com/apache/logging-log4j2/blob/rel/2.14.1/pom.xml#L1120
* https://github.com/netty/netty/blob/netty-4.1.70.Final/pom.xml#L1537