### PR TITLE
VERTXLIB-11: Deploy *-source.jar and *-javadoc.jar to folio-nexus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,48 @@
         </executions>
       </plugin>
 
+      <plugin>  <!-- *-source.jar for https://repository.folio.org -->
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>  <!-- *-javadoc.jar for https://repository.folio.org -->
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.3.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>  <!-- Enforce that this deploy runs AFTER attach-sources and attach-javadocs -->
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <executions>
+          <execution>
+            <id>deploy</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>deploy</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
When Jenkins runs mvn deploy it uploads the .jar files with the .class files to folio-nexus: https://repository.folio.org .

*-source.jar and *-javadoc.jar files should also be generated and uploaded so that IDEs display javadoc to developers and allow them to debug into the folio-vertx-lib code.

Therefore maven-source-plugin and maven-javadoc-plugin need to run at the beginning of the deploy phase.