### PR TITLE
Remove schema substitution VERTXLIB-22

### DIFF
--- a/core/src/main/java/org/folio/tlib/postgres/impl/TenantPgPoolImpl.java
+++ b/core/src/main/java/org/folio/tlib/postgres/impl/TenantPgPoolImpl.java
@@ -92,8 +92,6 @@ public class TenantPgPoolImpl implements TenantPgPool {
    * Create pool for Tenant.
    *
    * <p>The returned pool implements PgPool interface so this cab be used like PgPool as usual.
-   * But queries being substituted before usage. The literal "{schema}" is substituted with the
-   * module+schema.
    * PgPool.setModule *must* be called before the queries are executed, since schema is based
    * on module name.
    * @param vertx Vert.x handle
@@ -153,15 +151,10 @@ public class TenantPgPoolImpl implements TenantPgPool {
     return pgPool.getConnection();
   }
 
-  private String subst(String s) {
-    return s.replace("{schema}", getSchema());
-  }
-
   @Override
   public Query<RowSet<Row>> query(String s) {
-    String e = subst(s);
-    log.info("query {}", e);
-    return pgPool.query(e);
+    log.info("query {}", s);
+    return pgPool.query(s);
   }
 
   @Override
@@ -171,9 +164,8 @@ public class TenantPgPoolImpl implements TenantPgPool {
 
   @Override
   public PreparedQuery<RowSet<Row>> preparedQuery(String s, PrepareOptions prepareOptions) {
-    String e = subst(s);
-    log.info("preparedQuery {}", e);
-    return pgPool.preparedQuery(e, prepareOptions);
+    log.info("preparedQuery {}", s);
+    return pgPool.preparedQuery(s, prepareOptions);
   }
 
   @Override

--- a/core/src/test/java/org/folio/tlib/api/Tenant2ApiTest.java
+++ b/core/src/test/java/org/folio/tlib/api/Tenant2ApiTest.java
@@ -1,7 +1,6 @@
 package org.folio.tlib.api;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;


### PR DESCRIPTION
This is a breaking change. TenantPgPool.{execute,query,preparedQuery}
no longer maps {schema} to schema.