### PR TITLE
Add TenantPgPool.closeAll, update deps

### DIFF
--- a/core/src/main/java/org/folio/tlib/postgres/TenantPgPool.java
+++ b/core/src/main/java/org/folio/tlib/postgres/TenantPgPool.java
@@ -54,4 +54,8 @@ public interface TenantPgPool extends PgPool {
   static void setMaxPoolSize(String maxPoolSize) {
     TenantPgPoolImpl.setMaxPoolSize(maxPoolSize);
   }
+
+  static Future<Void> closeAll() {
+    return TenantPgPoolImpl.closeAll();
+  }
 }

--- a/core/src/main/java/org/folio/tlib/postgres/impl/TenantPgPoolImpl.java
+++ b/core/src/main/java/org/folio/tlib/postgres/impl/TenantPgPoolImpl.java
@@ -21,6 +21,7 @@ import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.Tuple;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.tlib.postgres.TenantPgPool;
 
 public class TenantPgPoolImpl implements TenantPgPool {
@@ -243,5 +245,17 @@ public class TenantPgPoolImpl implements TenantPgPool {
   @Override
   public int size() {
     return pgPool.size();
+  }
+
+  /**
+   * Close all pools.
+   * @return async result
+   */
+  public static Future<Void> closeAll() {
+    List<Future<Void>> futures = new ArrayList<>(pgPoolMap.size());
+    pgPoolMap.forEach((a,b) -> futures.add(b.close()));
+    return GenericCompositeFuture.all(futures)
+        .onComplete(x -> pgPoolMap.clear())
+        .mapEmpty();
   }
 }

--- a/core/src/test/java/org/folio/tlib/api/Tenant2ApiTest.java
+++ b/core/src/test/java/org/folio/tlib/api/Tenant2ApiTest.java
@@ -111,7 +111,9 @@ public class Tenant2ApiTest {
 
   @AfterClass
   public static void afterClass(TestContext context) {
-    vertx.close(context.asyncAssertSuccess());
+    TenantPgPool.closeAll()
+        .compose(x -> vertx.close())
+        .onComplete(context.asyncAssertSuccess());
   }
 
   @After

--- a/core/src/test/java/org/folio/tlib/postgres/TenantPgPoolTest.java
+++ b/core/src/test/java/org/folio/tlib/postgres/TenantPgPoolTest.java
@@ -249,6 +249,13 @@ public class TenantPgPoolTest {
   }
 
   @Test
+  public void closeAll(TestContext context) {
+    TenantPgPool pool = TenantPgPool.pool(vertx, "diku");
+    assertThat(pool.size(), is(0));
+    TenantPgPool.closeAll().onComplete(context.asyncAssertSuccess());
+  }
+
+  @Test
   public void connectHandler(TestContext context) {
     TenantPgPool pool = TenantPgPool.pool(vertx, "diku");
     pool.connectHandler(conn ->

--- a/core/src/test/java/org/folio/tlib/postgres/impl/TenantPgPoolImplTest.java
+++ b/core/src/test/java/org/folio/tlib/postgres/impl/TenantPgPoolImplTest.java
@@ -22,7 +22,9 @@ public class TenantPgPoolImplTest {
 
   @AfterClass
   public static void afterClass(TestContext context) {
-    vertx.close(context.asyncAssertSuccess());
+    TenantPgPoolImpl.closeAll()
+        .compose(x -> vertx.close())
+        .onComplete(context.asyncAssertSuccess());
   }
 
   @Before

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <okapi.version>4.14.3</okapi.version>
-    <vertx.version>4.3.3</vertx.version>
+    <okapi.version>4.14.5</okapi.version>
+    <vertx.version>4.3.4</vertx.version>
   </properties>
   <modules>
     <module>core</module>
@@ -49,7 +49,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.2</version>
+        <version>2.19.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -76,7 +76,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>4.5.1</version>
+        <version>5.2.0</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -91,7 +91,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This removes all cached pools. This is mostly useful in unit
tests where multiple Vert.x instances are at play.
