### PR TITLE
VERTXLIB-36: Upgrade to Vert.x 4.3.7 fixing Netty vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <okapi.version>4.14.7</okapi.version>
-    <vertx.version>4.3.5</vertx.version>
+    <vertx.version>4.3.7</vertx.version>
   </properties>
   <modules>
     <module>core</module>


### PR DESCRIPTION
Upgrade Vert.x from 4.3.5 to 4.3.7.

This indirectly upgrades Netty from 4.1.85.Final to 4.1.86.Final fixing HTTP Response Splitting and HAProxyMessageDecoder Stack Exhaustion DoS:

https://nvd.nist.gov/vuln/detail/CVE-2022-41915
https://github.com/netty/netty/security/advisories/GHSA-fx2c-96vj-985v https://vertx.io/blog/eclipse-vert-x-4-3-7/