### PR TITLE
FOLIO-3678 Workflows follow-up

### DIFF
--- a/core/src/main/resources/openapi/tenant-2.0.yaml
+++ b/core/src/main/resources/openapi/tenant-2.0.yaml
@@ -132,4 +132,3 @@ components:
       $ref: schemas/tenantJob.json
     errors:
       $ref: schemas/errors.json
-


### PR DESCRIPTION
The mainline branch Workflow api-schema-lint was showing a never-ending orange GitHub dot, rather than a green tick. But the workflow had finished with normal success. Dunno. Workflow weirdness.

Trying to trick it into going away.