### PR TITLE
VERTXLIB-49: Disable dependency reduced pom, disable mod-example javadoc

### DIFF
--- a/mod-example/pom.xml
+++ b/mod-example/pom.xml
@@ -203,6 +203,13 @@
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.6.0</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,14 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+        </configuration>
+      </plugin>
+      <plugin>
         <!-- *-source.jar for https://repository.folio.org -->
         <artifactId>maven-source-plugin</artifactId>
         <version>3.3.0</version>
@@ -190,7 +198,7 @@
         <executions>
           <execution>
             <id>attach-javadocs</id>
-            <phase>deploy</phase>
+            <phase>verify</phase>
             <goals>
               <goal>jar</goal>
             </goals>


### PR DESCRIPTION
https://issues.folio.org/browse/VERTXLIB-49

Disable dependency reduced pom so that all dependencies are published.

Disable javadoc generation of mod-example. It fails because of self-closing `<p/>` element that is illegal in strict HTML 4:
https://github.com/vert-x3/vertx-rx/pull/297

Generate javadoc in verify phase so that it fails early. The deploy phase is only executed when releasing.