### PR TITLE
VERTXLIB-50: Vert.x 4.4.6, Testcontainers 1.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <okapi.version>5.0.2</okapi.version>
-    <vertx.version>4.4.5</vertx.version>
+    <okapi.version>5.1.2</okapi.version>
+    <vertx.version>4.4.6</vertx.version>
   </properties>
   <modules>
     <module>core</module>
@@ -103,7 +103,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.19.0</version>
+        <version>1.19.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade Vert.x from 4.4.5 to 4.4.6. This indirectly upgrades Netty from 4.1.97.Final to 4.1.100.Final fixing Denial of Service (DoS):

https://nvd.nist.gov/vuln/detail/CVE-2023-44487

Upgrade Okapi from 5.0.2 to 5.1.2 to match the Vert.x version.

Upgrade Testcontainers from 1.19.0 to 1.19.1. This indirectly upgrades commons-compress from 1.23.0 to 1.24.0 fixing Improper Input Validation:

https://nvd.nist.gov/vuln/detail/CVE-2023-42503