### PR TITLE
VERTXLIB-54: log4j 2.23.0, commons-compress 1.26.0, .…

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,6 +132,18 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <!--
+         remove commons-compress dependency when testcontainers
+         comes with commons-compress >= 1.26.0 fixing
+         https://nvd.nist.gov/vuln/detail/CVE-2024-25710
+         https://nvd.nist.gov/vuln/detail/CVE-2024-26308
+         see https://github.com/testcontainers/testcontainers-java/pull/8354
+    -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pg-testing/pom.xml
+++ b/pg-testing/pom.xml
@@ -17,6 +17,17 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>
+    <!--
+         remove commons-compress dependency when testcontainers
+         comes with commons-compress >= 1.26.0 fixing
+         https://nvd.nist.gov/vuln/detail/CVE-2024-25710
+         https://nvd.nist.gov/vuln/detail/CVE-2024-26308
+         see https://github.com/testcontainers/testcontainers-java/pull/8354
+    -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.22.1</version>
+        <version>2.23.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -103,9 +103,21 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.19.5</version>
+        <version>1.19.6</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <!--
+         remove commons-compress dependency when testcontainers
+         comes with commons-compress >= 1.26.0 fixing
+         https://nvd.nist.gov/vuln/detail/CVE-2024-25710
+         https://nvd.nist.gov/vuln/detail/CVE-2024-26308
+         see https://github.com/testcontainers/testcontainers-java/pull/8354
+      -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.26.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Further upgrades for Quesnelia:

Upgrade log4j from 2.22.1 to 2.23.0.

Upgrade testcontainers from 1.19.5 to 1.19.6.

Upgrade commons-compress from 1.24.0 to 1.26.0 fixing
https://nvd.nist.gov/vuln/detail/CVE-2024-25710
https://nvd.nist.gov/vuln/detail/CVE-2024-26308
commons-compress is a testcontainers dependency, see
https://github.com/testcontainers/testcontainers-java/pull/8354