### PR TITLE
VERTXLIB-85: Trillium: Bump dependencies (Vertx 5.0.10, log4j 2.25.4, …)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # folio-vertx-lib
 
-Copyright (C) 2021-2025 The Open Library Foundation
+Copyright (C) 2021-2026 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
@@ -138,7 +138,7 @@ the minimal way to use the plugin is to use:
   <plugin>
     <groupId>org.folio</groupId>
     <artifactId>openapi-deref-plugin</artifactId>
-    <version>4.0.0</version>
+    <version>4.1.1</version>
     <executions>
       <execution>
         <id>dereference-books</id>

--- a/mod-example/pom.xml
+++ b/mod-example/pom.xml
@@ -160,7 +160,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -244,7 +244,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/openapi-deref-plugin/pom.xml
+++ b/openapi-deref-plugin/pom.xml
@@ -19,22 +19,20 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.18.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.18.2</version>
     </dependency>
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser</artifactId>
-      <version>2.1.32</version>
+      <version>2.1.39</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.15.1</version>
+      <version>3.15.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -45,7 +43,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.9.11</version>
+      <version>3.9.14</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -55,7 +53,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.0</version>
+        <version>3.15.0</version>
         <configuration>
           <release>21</release>
           <encoding>UTF-8</encoding>
@@ -65,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.12.0</version>
+        <version>3.15.2</version>
         <configuration>
           <goalPrefix>openapi-deref</goalPrefix>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <okapi.version>7.0.1</okapi.version>
-    <vertx.version>5.0.6</vertx.version>
+    <okapi.version>7.0.3</okapi.version>
+    <vertx.version>5.0.10</vertx.version>
   </properties>
   <modules>
     <module>openapi-deref-plugin</module>
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.25.1</version>
+        <version>2.25.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -77,24 +77,24 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>5.5.6</version>
+        <version>5.5.7</version>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.12.0</version>
+        <version>6.0.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>5.19.0</version>
+        <version>5.23.0</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -106,19 +106,19 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.4.2</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.0</version>
+        <version>3.15.0</version>
         <configuration>
           <release>21</release>
           <encoding>UTF-8</encoding>
@@ -153,12 +153,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.2</version>
+        <version>3.5.5</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.5.2</version>
+        <version>3.5.5</version>
         <executions>
           <execution>
             <goals>
@@ -171,7 +171,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.2</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
         </configuration>
@@ -179,7 +179,7 @@
       <plugin>
         <!-- *-source.jar for https://repository.folio.org -->
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -193,7 +193,7 @@
       <plugin>
         <!-- *-javadoc.jar for https://repository.folio.org -->
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.11.2</version>
+        <version>3.12.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -231,7 +231,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0</version>
         <configuration>
           <configLocation>google_checks.xml</configLocation>
           <violationSeverity>warning</violationSeverity>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/VERTXLIB-85

For Trillium bump all dependencies.

Runtime dependency bumps:

* Vert.x 5.0.6 → 5.0.10
* log4j 2.25.1 → 2.25.4
* swagger-parser 2.1.32 → 2.1.39

Also bump several test and build dependencies.