### PR TITLE
VERTXLIB-84: OpenAPI validation rejects double quote in param

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,12 +21,18 @@
       <artifactId>vertx-web-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.vertx</groupId>
+      <groupId>org.folio</groupId>
       <artifactId>vertx-openapi</artifactId>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-openapi-router</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>vertx-openapi</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/mod-example/pom.xml
+++ b/mod-example/pom.xml
@@ -33,14 +33,6 @@
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-openapi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-web-openapi-router</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
       <artifactId>vertx-rx-java2</artifactId>
     </dependency>
     <dependency>

--- a/mod-example/src/test/java/org/folio/tlib/example/MainVerticleTest.java
+++ b/mod-example/src/test/java/org/folio/tlib/example/MainVerticleTest.java
@@ -195,9 +195,10 @@ class MainVerticleTest {
         .body("books[0].title", is("Second title"))
         .body("books[1].title", is("First title"));
 
+    // query string with double quotes https://folio-org.atlassian.net/browse/VERTXLIB-84
     RestAssured.given()
         .header(XOkapiHeaders.TENANT, TENANT)
-        .queryParam("query", "title=first")
+        .queryParam("query", "title=\"first\"")
         .get("/books")
         .then().statusCode(200)
         .contentType(ContentType.JSON)

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- remove org.folio:vertx-openapi when using vertx.version >= 5.1.0 -->
+      <dependency>
+        <groupId>org.folio</groupId>
+        <artifactId>vertx-openapi</artifactId>
+        <version>5.0.990</version>
+      </dependency>
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-common</artifactId>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/VERTXLIB-84

vertx-openapi validator reject a stringparameter that includes a double-quote, for example
`/books?query=cql.allRecords=%22true%22`.

This is a known issue and no plan to fix in 5.0 series:
* https://github.com/eclipse-vertx/vertx-openapi/issues/98
* https://github.com/eclipse-vertx/vertx-openapi/pull/108

Solution: Use `org.folio:vertx-openapi:5.0.990`, a release of our fork of the upstream `io.vertx:vertx-openapi:5.1.0-SNAPSHOT`.