### PR TITLE
VERTXLIB-86 Vert.x 5.1.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,18 +21,12 @@
       <artifactId>vertx-web-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.folio</groupId>
+      <groupId>io.vertx</groupId>
       <artifactId>vertx-openapi</artifactId>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-openapi-router</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.vertx</groupId>
-          <artifactId>vertx-openapi</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <okapi.version>7.0.3</okapi.version>
-    <vertx.version>5.0.10</vertx.version>
+    <okapi.version>7.0.4</okapi.version>
+    <vertx.version>5.1.0</vertx.version>
   </properties>
   <modules>
     <module>openapi-deref-plugin</module>
@@ -55,11 +55,6 @@
         <scope>import</scope>
       </dependency>
       <!-- remove org.folio:vertx-openapi when using vertx.version >= 5.1.0 -->
-      <dependency>
-        <groupId>org.folio</groupId>
-        <artifactId>vertx-openapi</artifactId>
-        <version>5.0.990</version>
-      </dependency>
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-common</artifactId>


### PR DESCRIPTION
I don't know if this should be Trillium , now that Vert.x is bumped to 5.1.. But in this case, for FOLIO, it is a bug fix release.

https://folio-org.atlassian.net/browse/VERTXLIB-86