### PR TITLE
VERTXLIB-87: Vertx 5.0.5, Netty 4.2.16, Jackson 2.21.5/3.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <okapi.version>7.0.4</okapi.version>
-    <vertx.version>5.1.0</vertx.version>
+    <vertx.version>5.1.5</vertx.version>
   </properties>
   <modules>
     <module>openapi-deref-plugin</module>
@@ -54,7 +54,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- remove org.folio:vertx-openapi when using vertx.version >= 5.1.0 -->
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-common</artifactId>
@@ -286,6 +285,6 @@
   </distributionManagement>
   <issueManagement>
     <system>JIRA</system>
-    <url>https://issues.folio.org/browse/VERTXLIB</url>
+    <url>https://folio-org.atlassian.net/jira/software/c/projects/VERTXLIB/list</url>
   </issueManagement>
 </project>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/VERTXLIB-87

Upgrade Vert.x from 5.1.0 to 5.1.5.

The Vert.x upgrade

* transitively upgrades Netty from 4.2.14.Final to 4.2.16.Final
* transitively upgrades Jackson 2 from 2.21.3 to 2.21.5
* transitively upgrades Jackson 3 from 3.1.3 to 3.1.5

The Netty upgrade fixes multiple security vulnerabilities:

* CVE-2026-48059: memory exhaustion in io.netty:netty-codec-haproxy (high).
* CVE-2026-47691: DNS cache poisoning in io.netty:netty-resolver-dns (high).
* CVE-2026-50560: DDoS in io.netty:netty-codec-http2.
* CVE-2026-50011: memory exhaustion in io.netty:netty-codec-redis (high).
* CVE-2026-44250: memory exhaustion in io.netty:netty-codec-redis (high).
* CVE-2026-44890: memory exhaustion in io.netty:netty-codec-redis (high).
* CVE-2026-50009: information disclosure and denial of service in io.netty:netty-codec-classes-quic.
* CVE-2026-44249: IPv6 subnet filter bypass in io.netty:netty-handler (high).
* CVE-2026-50020: request smuggling in io.netty:netty-codec-http.
* CVE-2026-44892: memory exhaustion in io.netty:netty-codec-http3 (high).
* CVE-2026-44893: memory leak in io.netty:netty-codec-haproxy (high).
* CVE-2026-44894: traffic amplification in io.netty:netty-codec-classes-quic (high).
* CVE-2026-50010: TLS hostname verification accidentally disabled in io.netty:netty-handler (high).
* CVE-2026-45673: DNS cache poisoning in io.netty:netty-resolver-dns.
* CVE-2026-45416: excessive memory usage from SNIHandler in io.netty:netty-handler (high).
* CVE-2026-45536: file descriptor leak in io.netty:netty-transport-native-epoll and io.netty:netty-transport-native-kqueue.
* CVE-2026-45674: DNS cache poisoning in io.netty:netty-resolver-dns (high).
* CVE-2026-46340: memory exhaustion in io.netty:netty-transport-sctp (high).
* CVE-2026-47244: denial of service in io.netty:netty-codec-http2.
* CVE-2026-48006: memory exhaustion in io.netty:netty-codec-redis (high).
* CVE-2026-48748: memory exhaustion in io.netty:netty-codec-http3 (high).
* CVE-2026-48043: memory exhaustion in io.netty:netty-codec-http2.

The Jackson upgrade fixes multiple security vulnerabilities:

* @JsonView by-passed for @JsonUnwrapped Field/Setter properties [CVE-2026-59889] https://nvd.nist.gov/vuln/detail/CVE-2026-59889
* Improve InetSocketAddress deserialization [CVE-2026-54514]
* Case-insensitive deserialization may use wrong @JsonIgnoreProperties [CVE-2026-54515]
* Renamed @JsonIgnored setters can deserialize via private fields [CVE-2026-54516]
* @JsonView by-passed for some "setterless" creator properties [CVE-2026-54517]
* @JsonView by-passed for unwrapped creator parameters [CVE-2026-54518]
* @JsonIgnore on Record property ignored with PropertyNamingStrategy [CVE-2026-59888] https://nvd.nist.gov/vuln/detail/CVE-2026-59888
* BasicPolymorphicTypeValidator setting allowIfSubTypeIsArray() should validate element type [CVE-2026-54513]
* PolymorphicTypeValidator needs to validate generic type parameters too [CVE-2026-54512]