### PR TITLE
VERTXLIB-88: swagger-parser 2.1.45, rhino 1.7.15.1

### DIFF
--- a/openapi-deref-plugin/pom.xml
+++ b/openapi-deref-plugin/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>io.swagger.parser.v3</groupId>
       <artifactId>swagger-parser</artifactId>
-      <version>2.1.39</version>
+      <version>2.1.45</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/VERTXLIB-88

In openapi-deref-plugin bump swagger-parser from 2.1.39 to 2.1.45.

This transitively bumps rhino from 1.7.7.2 to 1.7.15.1 fixing two security vulnerabilities:

* [CVE-2025-66453](https://www.cve.org/CVERecord?id=CVE-2025-66453) – GHSA-3w8q-xq97-5j7x – toFixed – Allocation of Resources Without Limits or Throttling
* [SNYK-JAVA-ORGMOZILLA-1314295](https://security.snyk.io/vuln/SNYK-JAVA-ORGMOZILLA-1314295) – XML External Entity (XXE) Injection